### PR TITLE
Remove Uivk Support

### DIFF
--- a/zcash_client_memory/src/types/account.rs
+++ b/zcash_client_memory/src/types/account.rs
@@ -56,7 +56,7 @@ impl Accounts {
     pub(crate) fn new_account(
         &mut self,
         kind: AccountSource,
-        viewing_key: ViewingKey,
+        viewing_key: UnifiedFullViewingKey,
         birthday: AccountBirthday,
         purpose: AccountPurpose,
     ) -> Result<(AccountId, Account), Error> {
@@ -72,7 +72,7 @@ impl Accounts {
         };
         let ua_request = acc
             .viewing_key
-            .uivk()
+            .to_unified_incoming_viewing_key()
             .to_address_request()
             .and_then(|ua_request| ua_request.intersect(&UnifiedAddressRequest::all().unwrap()))
             .ok_or_else(|| {
@@ -129,27 +129,11 @@ impl DerefMut for Accounts {
 pub struct Account {
     account_id: AccountId,
     kind: AccountSource,
-    viewing_key: ViewingKey,
+    viewing_key: UnifiedFullViewingKey,
     birthday: AccountBirthday,
     _purpose: AccountPurpose, // TODO: Remove this. AccountSource should be sufficient.
     addresses: BTreeMap<DiversifierIndex, UnifiedAddress>,
     _notes: HashSet<NoteId>,
-}
-
-/// The viewing key that an [`Account`] has available to it.
-#[derive(Debug, Clone)]
-pub(crate) enum ViewingKey {
-    /// A full viewing key.
-    ///
-    /// This is available to derived accounts, as well as accounts directly imported as
-    /// full viewing keys.
-    Full(Box<UnifiedFullViewingKey>),
-
-    /// An incoming viewing key.
-    ///
-    /// Accounts that have this kind of viewing key cannot be used in wallet contexts,
-    /// because they are unable to maintain an accurate balance.
-    _Incoming(Box<UnifiedIncomingViewingKey>),
 }
 
 impl Account {
@@ -181,9 +165,7 @@ impl Account {
     pub(crate) fn kind(&self) -> &AccountSource {
         &self.kind
     }
-    pub(crate) fn _viewing_key(&self) -> &ViewingKey {
-        &self.viewing_key
-    }
+
     pub(crate) fn next_available_address(
         &mut self,
         request: UnifiedAddressRequest,
@@ -222,26 +204,10 @@ impl zcash_client_backend::data_api::Account<AccountId> for Account {
     }
 
     fn ufvk(&self) -> Option<&UnifiedFullViewingKey> {
-        self.viewing_key.ufvk()
+        Some(&self.viewing_key)
     }
 
     fn uivk(&self) -> UnifiedIncomingViewingKey {
-        self.viewing_key.uivk()
-    }
-}
-
-impl ViewingKey {
-    fn ufvk(&self) -> Option<&UnifiedFullViewingKey> {
-        match self {
-            ViewingKey::Full(ufvk) => Some(ufvk),
-            ViewingKey::_Incoming(_) => None,
-        }
-    }
-
-    fn uivk(&self) -> UnifiedIncomingViewingKey {
-        match self {
-            ViewingKey::Full(ufvk) => ufvk.as_ref().to_unified_incoming_viewing_key(),
-            ViewingKey::_Incoming(uivk) => uivk.as_ref().clone(),
-        }
+        self.viewing_key.to_unified_incoming_viewing_key()
     }
 }

--- a/zcash_client_memory/src/wallet_write.rs
+++ b/zcash_client_memory/src/wallet_write.rs
@@ -29,7 +29,7 @@ use zcash_client_backend::data_api::{
 };
 
 use crate::{error::Error, PRUNING_DEPTH, VERIFY_LOOKAHEAD};
-use crate::{Accounts, MemoryWalletBlock, MemoryWalletDb, Nullifier, ReceivedNote, ViewingKey};
+use crate::{Accounts, MemoryWalletBlock, MemoryWalletDb, Nullifier, ReceivedNote};
 use maybe_rayon::prelude::*;
 
 #[cfg(feature = "orchard")]
@@ -62,7 +62,7 @@ impl<P: consensus::Parameters> WalletWrite for MemoryWalletDb<P> {
                 seed_fingerprint,
                 account_index,
             },
-            ViewingKey::Full(Box::new(ufvk)),
+            ufvk,
             birthday.clone(),
             AccountPurpose::Spending,
         )?;
@@ -468,7 +468,7 @@ impl<P: consensus::Parameters> WalletWrite for MemoryWalletDb<P> {
                 seed_fingerprint,
                 account_index,
             },
-            ViewingKey::Full(Box::new(ufvk)),
+            ufvk,
             birthday.clone(),
             AccountPurpose::Spending,
         )?;
@@ -486,7 +486,7 @@ impl<P: consensus::Parameters> WalletWrite for MemoryWalletDb<P> {
         let (_id, account) = Accounts::new_account(
             &mut self.accounts,
             AccountSource::Imported { purpose },
-            ViewingKey::Full(Box::new(unified_key.to_owned())),
+            unified_key.to_owned(),
             birthday.clone(),
             purpose,
         )?;


### PR DESCRIPTION
The api only allows for importing of Ufvk's anyways. No need to separately handle the case where accounts only have Uivk